### PR TITLE
Fixes #11: list users

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,8 +5,9 @@ indent_style = space
 indent_size = 4
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = false
-insert_final_newline = false
+trim_trailing_whitespace = true
+insert_final_newline = true
+
 
 [*.html]
 indent_size = 2

--- a/chat/consumers.py
+++ b/chat/consumers.py
@@ -129,15 +129,17 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):
             raise ClientError("ROOM_ACCESS_DENIED")
         # Get the room and send to the group about it
         room: Room = await get_room_or_error(room_id, self.scope["user"])
+        user: User = self.scope['user']
         await self.channel_layer.group_send(
             room.group_name,
             {
                 "type": "chat.message",
                 "room_id": room_id,
-                "username": self.scope["user"].username,
+                "username": user.username,
                 "message": message,
             }
         )
+        await cache_or_update_room_presence(room_id, user)
 
     async def room_users(self, room_id: int) -> None:
         """Called when asking for list of the online users in the room."""

--- a/chat/tests/test_chat_consumer.py
+++ b/chat/tests/test_chat_consumer.py
@@ -14,14 +14,21 @@ def create_room() -> Room:
 
 
 @database_sync_to_async
-def create_user() -> User:
-    return User.objects.create_user(email='ali@email.com', username='alireza', password='somepassword', is_staff=True)
+def create_user(email: str, username: str, name: str) -> User:
+    return User.objects.create_user(email=email, username=username, name=name, password='somepassword', is_staff=True)
+
+
+@database_sync_to_async
+def tear_down() -> None:
+    User.objects.filter().delete()
 
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
 async def test_chat_consumer() -> None:
-    user = await create_user()
+    user: User = await create_user(email='ali@email.com', username='alireza', name='Alireza Savand')
+    user_2: User = await create_user(email='amir@email.com', username='amir', name='Amir Savand')
+
     room = await create_room()
     communicator = WebsocketCommunicator(ChatConsumer, "/testws/")
     communicator.scope['user'] = user
@@ -33,7 +40,6 @@ async def test_chat_consumer() -> None:
     # Joining a room that doesn't exists
     await communicator.send_json_to({"command": "join", "room": '5451'})
     response = await communicator.receive_json_from()
-    print(response)
     assert response == {'error': 'ROOM_INVALID'}
 
     # Test joining
@@ -52,8 +58,63 @@ async def test_chat_consumer() -> None:
                         'username': user.username,
                         'message': message}
 
-    # Testing Leaving the room
+    # Getting list of users in the room
+    await communicator.send_json_to({'command': 'room_users', 'room': room.id})
+    response = await communicator.receive_json_from()
+    assert response == {'data': {'users': {'1': {'name': 'Alireza Savand', 'username': 'alireza'}}},
+                        'type': settings.MSG_TYPE_INTERNAL, 'room': room.id}
+
+    communicator_2 = WebsocketCommunicator(ChatConsumer, "/testws/")
+    communicator_2.scope['user'] = user_2
+    connected, _ = await communicator_2.connect()
+    assert connected
+
+    await communicator_2.send_json_to({"command": "join", "room": room.id})
+    response = await communicator_2.receive_json_from()
+    assert response == {'join': str(room.id), 'title': 'Savand Bros'}
+
+    response = await communicator.receive_json_from()
+    assert response == {'msg_type': settings.MSG_TYPE_ENTER, 'room': room.id, 'username': user_2.username}
+
+    assert communicator_2.instance.rooms == set(list([room.id, ]))
+
+    await communicator_2.send_json_to({'command': 'room_users', 'room': room.id})
+    response = await communicator_2.receive_json_from()
+    assert response == {
+        'data': {
+            'users': {
+                '1': {'username': user.username, 'name': user.name},
+                '2': {'username': user_2.username, 'name': user_2.name}
+            }
+        },
+        'type': settings.MSG_TYPE_INTERNAL, 'room': room.id
+    }
+
+    # User:Alireza gonna leave the room and Amir should be notified.
     await communicator.send_json_to({"command": "leave", "room": room.id})
     response = await communicator.receive_json_from()
     assert response == {'leave': str(room.id)}
     assert communicator.instance.rooms == set()
+
+    # Here User: Amir has been notified about Alireza leaving.
+    response = await communicator_2.receive_json_from()
+    assert response == {'msg_type': settings.MSG_TYPE_LEAVE, 'room': room.id, 'username': user.username}
+
+    # Let's get the users online the room now since Alireza has left us alone
+    await communicator_2.send_json_to({'command': 'room_users', 'room': room.id})
+    response = await communicator_2.receive_json_from()
+    assert response == {'data': {'users': {'2': {'username': user_2.username, 'name': user_2.name}}},
+                        'type': settings.MSG_TYPE_INTERNAL, 'room': room.id}
+
+    # User: Amir is leaving the room
+    await communicator_2.send_json_to({"command": "leave", "room": room.id})
+    response = await communicator_2.receive_json_from()
+    assert response == {'leave': str(room.id)}
+    assert communicator_2.instance.rooms == set()
+
+    # Finally disconnecting
+    await communicator.disconnect()
+    await communicator_2.disconnect()
+
+    # Teardown
+    await tear_down()

--- a/chat/tests/test_chat_consumer.py
+++ b/chat/tests/test_chat_consumer.py
@@ -78,6 +78,33 @@ async def test_chat_consumer() -> None:
         'type': settings.MSG_TYPE_INTERNAL, 'room': room.id
     }
 
+    # Testing Sending Message and getting last updated newer
+    message: str = 'Hello Alireza'
+    await communicator.send_json_to({"command": "send", "room": room.id, 'message': message})
+    response = await communicator.receive_json_from()
+    assert response == {'msg_type': settings.MSG_TYPE_MESSAGE,
+                        'room': room.id,
+                        'username': user.username,
+                        'message': message}
+
+    await communicator.send_json_to({'command': 'room_users', 'room': room.id})
+    response = await communicator.receive_json_from()
+    last_update_now: float = response['data']['users']['1']['last_update']
+    assert last_update_now > last_update
+    assert response == {
+        'data': {
+            'users': {
+                '1': {
+                    'name': 'Alireza Savand',
+                    'username': 'alireza',
+                    'left': False,
+                    'last_update': last_update_now
+                }
+            }
+        },
+        'type': settings.MSG_TYPE_INTERNAL, 'room': room.id
+    }
+
     communicator_2 = WebsocketCommunicator(ChatConsumer, "/testws/")
     communicator_2.scope['user'] = user_2
     connected, _ = await communicator_2.connect()

--- a/chat/utils.py
+++ b/chat/utils.py
@@ -40,7 +40,8 @@ def cache_or_update_room_presence(room_id: int, user: User) -> None:
     if not room_cached:
         cache.set(cache_key, user_data)
     else:
-        cache.set(cache_key, room_cached.update(user_data))
+        room_cached.update(user_data)
+        cache.set(cache_key, room_cached)
 
 
 @database_sync_to_async
@@ -52,9 +53,13 @@ def get_presence_users(room_id: int) -> Dict[int, Dict[str, str]]:
 @database_sync_to_async
 def remove_user_from_presence(room_id: int, user_id: int) -> None:
     """Remove user from the room presence."""
-    room_cached = cache.get(get_room_presence_cache_key(room_id))
+    cache_key = get_room_presence_cache_key(room_id)
+    room_cached = cache.get(cache_key)
+
     if room_cached:
         room_cached.pop(user_id)
+
+    cache.set(cache_key, room_cached)
 
 
 def get_room_presence_cache_key(room_id: int) -> str:

--- a/chat/utils.py
+++ b/chat/utils.py
@@ -1,8 +1,11 @@
-from channels.db import database_sync_to_async
-
 # This decorator turns this function from a synchronous function into an async one
 # we can call from our async consumers, that handles Django DBs correctly.
 # For more, see http://channels.readthedocs.io/en/latest/topics/databases.html
+from typing import Dict
+
+from channels.db import database_sync_to_async
+from django.core.cache import cache
+
 from chat.exceptions import ClientError
 from chat.models import Room
 from users.models import User
@@ -25,3 +28,35 @@ def get_room_or_error(room_id: int, user: User):
     if room.staff_only and not user.is_staff:
         raise ClientError("ROOM_ACCESS_DENIED")
     return room
+
+
+@database_sync_to_async
+def cache_or_update_room_presence(room_id: int, user: User) -> None:
+    """Cache or update user presence in the room."""
+    cache_key = get_room_presence_cache_key(room_id)
+    room_cached = cache.get(cache_key)
+    user_data: Dict[int, Dict[str, str]] = {user.id: {'username': user.username, 'name': user.name}}
+
+    if not room_cached:
+        cache.set(cache_key, user_data)
+    else:
+        cache.set(cache_key, room_cached.update(user_data))
+
+
+@database_sync_to_async
+def get_presence_users(room_id: int) -> Dict[int, Dict[str, str]]:
+    """Return all the presence users in the room."""
+    return cache.get(get_room_presence_cache_key(room_id))
+
+
+@database_sync_to_async
+def remove_user_from_presence(room_id: int, user_id: int) -> None:
+    """Remove user from the room presence."""
+    room_cached = cache.get(get_room_presence_cache_key(room_id))
+    if room_cached:
+        room_cached.pop(user_id)
+
+
+def get_room_presence_cache_key(room_id: int) -> str:
+    """Return Room Presence Cache Key."""
+    return f'room-presence-{room_id}'

--- a/chat/utils.py
+++ b/chat/utils.py
@@ -4,7 +4,9 @@
 from typing import Dict
 
 from channels.db import database_sync_to_async
+from django.conf import settings
 from django.core.cache import cache
+from django.utils import timezone
 
 from chat.exceptions import ClientError
 from chat.models import Room
@@ -35,13 +37,20 @@ def cache_or_update_room_presence(room_id: int, user: User) -> None:
     """Cache or update user presence in the room."""
     cache_key = get_room_presence_cache_key(room_id)
     room_cached = cache.get(cache_key)
-    user_data: Dict[int, Dict[str, str]] = {user.id: {'username': user.username, 'name': user.name}}
+    users_data: Dict[int, Dict[str, str]] = {
+        user.id: {
+            'username': user.username,
+            'name': user.name,
+            'left': False,
+            'last_update': timezone.now().timestamp()
+        }
+    }
 
     if not room_cached:
-        cache.set(cache_key, user_data)
+        cache.set(cache_key, users_data, timeout=settings.ROOM_PRESENCE_TIMEOUT)
     else:
-        room_cached.update(user_data)
-        cache.set(cache_key, room_cached)
+        room_cached.update(users_data)
+        cache.set(cache_key, room_cached, timeout=settings.ROOM_PRESENCE_TIMEOUT)
 
 
 @database_sync_to_async
@@ -55,11 +64,13 @@ def remove_user_from_presence(room_id: int, user_id: int) -> None:
     """Remove user from the room presence."""
     cache_key = get_room_presence_cache_key(room_id)
     room_cached = cache.get(cache_key)
+    # Purge users that have left 2 hours ago!
 
     if room_cached:
-        room_cached.pop(user_id)
+        user_data: dict = room_cached[user_id]
+        user_data.update({'left': True})
 
-    cache.set(cache_key, room_cached)
+    cache.set(cache_key, room_cached, timeout=settings.ROOM_PRESENCE_TIMEOUT)
 
 
 def get_room_presence_cache_key(room_id: int) -> str:

--- a/whisper/settings.py
+++ b/whisper/settings.py
@@ -7,7 +7,7 @@ import os
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 env = environ.Env()
-TESTING: bool = sys.argv[1:2] == ['test']
+TESTING: bool = sys.argv[1:2] == ['test'] or 'test' in sys.argv[0]
 
 ##### Channels-specific settings
 # Channel layer definitions
@@ -36,6 +36,7 @@ MSG_TYPE_ALERT = 2  # For red & dangerous alerts
 MSG_TYPE_MUTED = 3  # For just OK information that doesn't bother users
 MSG_TYPE_ENTER = 4  # For just OK information that doesn't bother users
 MSG_TYPE_LEAVE = 5  # For just OK information that doesn't bother users
+MSG_TYPE_INTERNAL = 6  # For just ok information that should be between server-client
 
 MESSAGE_TYPES_CHOICES = (
     (MSG_TYPE_MESSAGE, 'MESSAGE'),
@@ -44,6 +45,7 @@ MESSAGE_TYPES_CHOICES = (
     (MSG_TYPE_MUTED, 'MUTED'),
     (MSG_TYPE_ENTER, 'ENTER'),
     (MSG_TYPE_LEAVE, 'LEAVE'),
+    (MSG_TYPE_INTERNAL, 'INTERNAL')
 )
 
 MESSAGE_TYPES_LIST = [
@@ -53,8 +55,8 @@ MESSAGE_TYPES_LIST = [
     MSG_TYPE_MUTED,
     MSG_TYPE_ENTER,
     MSG_TYPE_LEAVE,
+    MSG_TYPE_INTERNAL
 ]
-
 
 ##### Normal Django settings
 
@@ -166,6 +168,14 @@ if not TESTING:
             "KEY_PREFIX": "whisper"
         }
     }
+else:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'unique-snowflake',
+        }
+    }
+
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 
 

--- a/whisper/settings.py
+++ b/whisper/settings.py
@@ -58,6 +58,8 @@ MESSAGE_TYPES_LIST = [
     MSG_TYPE_INTERNAL
 ]
 
+ROOM_PRESENCE_TIMEOUT: int = 3600  # 1 hours
+
 ##### Normal Django settings
 
 # SECURITY WARNING: keep the secret key used in production secret! And don't use debug=True in production!


### PR DESCRIPTION
Fixes #11

This should be enough for now, however in no case this is solid and stable.
It all depends on the cache (redis) and later I should add a "hearbeat" to know which connection is alive, although the hearbeat would add extra load since it has to be fired every N seconds. 

Anyway, this can be merged after passing the review and in another issue I can continue to make it more solid-ish.

In another pull request I will implement a solution to keep the cache fresh by each message.
So when a user (live-connection) sends a message to websocket, I renew the cache entry timeout and if the user didn't message it will automatically get removed from the cache.

I don't want to implement that into this pull request, because it will make it large and harder to review properly.